### PR TITLE
Support page ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ function calculate()
     document.getElementById("singlesided").style.display = "block";
   }
 
-  count = document.getElementById('count').value;
+  count = parseInt(document.getElementById('count').value);
   var duplexlist = '';
   var side1list = '';
   var side2list = '';
@@ -56,6 +56,11 @@ function calculate()
   document.getElementById('side1list').value = side1list;
   document.getElementById('side2list').value = side2list;
   document.getElementById('duplexlist').value = duplexlist;
+}
+
+function userUpdatesCount()
+{
+  calculate();
 }
 
 function init()
@@ -119,8 +124,8 @@ document.addEventListener("DOMContentLoaded", init);
           <ul class="list-group"> 
             <li class="list-group-item">Make sure your document's page count is <b>divisible by 4</b>, i.e. it contains 4 or 8 or 12 or ... pages. If not, add empty pages.</li>
             <li class="list-group-item">
-              Select the page count of your document:
-              <select class="chosen-select"  id="count" onchange="calculate();"> </select>
+              Select the number of pages to print:
+              <select class="chosen-select"  id="count" onchange="userUpdatesCount();"> </select>
             </li>
             <li class="list-group-item"> 
               Does your printer print double-sided?

--- a/index.html
+++ b/index.html
@@ -60,14 +60,50 @@ function calculate()
   document.getElementById('duplexlist').value = duplexlist;
 }
 
-function userUpdatesCount()
-{
+function userUpdatesCount() {
+  // If the user changes the page count, we need to update the last page dropdown
+  count = parseInt(document.getElementById('count').value);
+  firstPage = parseInt(document.getElementById('firstPage').value);
+  lastPage = firstPage - 1 + count;
+  document.getElementById('lastPage').value = lastPage;
+  $("#lastPage").trigger("chosen:updated");
+
   calculate();
 }
 
-function userUpdatesFirstPage()
-{
+function userUpdatesFirstPage() {
+  // If the user changes the first page, we need to adjust the selectable values
+  // of the last page dropdown and set the value according to the page count
+  count = parseInt(document.getElementById('count').value);
+  firstPage = parseInt(document.getElementById('firstPage').value);
+  updateLastPageOptions(firstPage);
+  lastPage = firstPage - 1 + count;
+  document.getElementById('lastPage').value = lastPage;
+  $("#lastPage").trigger("chosen:updated");
+
   calculate();
+}
+
+function userUpdatesLastPage() {
+  // If the user changes the last page, we need to adjust the page count dropdown
+  firstPage = parseInt(document.getElementById('firstPage').value);
+  lastPage = parseInt(document.getElementById('lastPage').value);
+  count = lastPage - firstPage + 1;
+  document.getElementById('count').value = count;
+  $("#count").trigger("chosen:updated");
+
+  calculate();
+}
+
+function updateLastPageOptions(firstPage) {
+  // Adjust the selectable values of the last page dropdown according to the
+  // first page
+  selectLastPage = document.getElementById('lastPage');
+  selectLastPage.options.length = 0;
+
+  for (var i = firstPage + 3; i <= 1000 + firstPage - 1; i = i + 4) {
+    selectLastPage.options[selectLastPage.length] = new Option(i);
+  }
 }
 
 function init()
@@ -86,6 +122,12 @@ function init()
   }
   selectFirstPage.value = 1;
   $("#firstPage").trigger("chosen:updated");
+
+  // populate and set the last page dropdown
+  updateLastPageOptions(1);
+  selectLastPage = document.getElementById('lastPage');
+  selectLastPage.value = 4;
+  $("#lastPage").trigger("chosen:updated");
 
   calculate();
 }
@@ -117,7 +159,7 @@ document.addEventListener("DOMContentLoaded", init);
     form{
       font-size: 17px;
     }
-    #count_chosen, #firstPage_chosen{
+    #count_chosen, #firstPage_chosen, #lastPage_chosen {
       width: 100px !important;
     }
   </style>
@@ -147,6 +189,10 @@ document.addEventListener("DOMContentLoaded", init);
             <li class="list-group-item">
               Select the first page to print:
               <select class="chosen-select"  id="firstPage" onchange="userUpdatesFirstPage();"> </select>
+            </li>
+            <li class="list-group-item">
+              Select the last page to print:
+              <select class="chosen-select"  id="lastPage" onchange="userUpdatesLastPage();"> </select>
             </li>
             <li class="list-group-item">
               Does your printer print double-sided?

--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@ function calculate()
   }
 
   count = parseInt(document.getElementById('count').value);
+  firstPage = parseInt(document.getElementById('firstPage').value);
+  offset = firstPage - 1;
   var duplexlist = '';
   var side1list = '';
   var side2list = '';
@@ -33,14 +35,14 @@ function calculate()
     var new1;
     var new2;
     if (direction == "LTR") {
-      var new1 = (count - i+1).toString() + ',' + i.toString() + ',';
-      var new2 = (i + 1).toString() + ',' + (count - i).toString() + ',';
+      var new1 = (offset + count - i+1).toString() + ',' + (offset + i).toString() + ',';
+      var new2 = (offset + i + 1).toString() + ',' + (offset + count - i).toString() + ',';
     }
     else {
       // RTL; this is the above two lines with each pair of numbers in the
       // other order
-      var new1 = i.toString() + ',' + (count - i+1).toString() + ',';
-      var new2 = (count - i).toString() + ',' + (i + 1).toString() + ',';
+      var new1 = (offset + i).toString() + ',' + (offset + count - i+1).toString() + ',';
+      var new2 = (offset + count - i).toString() + ',' + (offset + i + 1).toString() + ',';
     }
 
     side1list = side1list + new1;
@@ -63,13 +65,28 @@ function userUpdatesCount()
   calculate();
 }
 
+function userUpdatesFirstPage()
+{
+  calculate();
+}
+
 function init()
 {
+  // populate and set the page count dropdown
   selectCount = document.getElementById('count');
   for (var i = 4; i <= 1000; i = i + 4) {
     selectCount.options[selectCount.length] = new Option(i);
   }
   $("#count").trigger("chosen:updated");
+
+  // populate and set the first page dropdown
+  selectFirstPage = document.getElementById('firstPage');
+  for (var i = 1; i <= 1000; i++) {
+    selectFirstPage.options[selectFirstPage.length] = new Option(i);
+  }
+  selectFirstPage.value = 1;
+  $("#firstPage").trigger("chosen:updated");
+
   calculate();
 }
 function copyToClipboard(id) {
@@ -100,7 +117,7 @@ document.addEventListener("DOMContentLoaded", init);
     form{
       font-size: 17px;
     }
-    #count_chosen{
+    #count_chosen, #firstPage_chosen{
       width: 100px !important;
     }
   </style>
@@ -127,7 +144,11 @@ document.addEventListener("DOMContentLoaded", init);
               Select the number of pages to print:
               <select class="chosen-select"  id="count" onchange="userUpdatesCount();"> </select>
             </li>
-            <li class="list-group-item"> 
+            <li class="list-group-item">
+              Select the first page to print:
+              <select class="chosen-select"  id="firstPage" onchange="userUpdatesFirstPage();"> </select>
+            </li>
+            <li class="list-group-item">
               Does your printer print double-sided?
               <select  id="duplex" onchange="calculate();">
                 <option value="No">No</option>


### PR DESCRIPTION
Thanks for the excellent booklet calculator!!!

I want to be able to print page ranges, so not just starting at page 1. This lets me turn individual sections of a larger document into a booklet.

I usually think in terms of first/last page, so I added selectors for those. If you ignore the first/last page selectors, the tool operates exactly as before. But now you can also set the first and last page. Updating the page count automatically adjusts the last page, leaving the first page unchanged. Updating the first page automatically adjusts the last page, leaving the page count unchanged. Updating the last page automatically adjusts the page count, leaving the first page unchanged.

![image](https://github.com/user-attachments/assets/22851153-4c16-4e77-9a32-0147a88787a7)
